### PR TITLE
Simplify configuration for the dockerized execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Note: cypress-multi-reporters is required because gocd-cypress uses it through C
 {
     "scripts": {
         "test:e2e": "gocd-cypress",
-        "test:e2eStandalone": "gocd-cypress --serveCmd='npm start' --serveHost='http://localhost:4200'",
+        "test:e2eStandalone": "gocd-cypress --serveCmd='npm start' --serveHost=http://localhost:4200"
     }
 }
 ```

--- a/project-under-test/.gitignore
+++ b/project-under-test/.gitignore
@@ -6,7 +6,3 @@
 /cypress/screenshots
 /cypress/results
 /cypress/reports
-/.cache
-/.config
-/.local
-/.mozilla

--- a/project-under-test/package.json
+++ b/project-under-test/package.json
@@ -7,7 +7,7 @@
     "//": "linking package does not work properly - recursive linking",
     "postinstall": "npm install --no-save $(npm pack ../ | tail -1)",
     "start": "node tools/fake-serve.js",
-    "test": "gocd-cypress"
+    "test": "gocd-cypress --serveCmd='npm start' --serveHost=http://localhost:4200"
   },
   "keywords": [],
   "devDependencies": {

--- a/project-under-test/tools/fake-serve.js
+++ b/project-under-test/tools/fake-serve.js
@@ -11,6 +11,9 @@ http.createServer()
 		res.writeHead(200);
 		res.end(html);
 	})
+	.on('error', function (e) {
+		console.error(e);
+	})
 	.listen(port, host, () => {
 		console.log(`Fake development web server is running on http://${host}:${port} ...`);
 	});

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -25,7 +25,7 @@ export function buildCli(): Argv {
 
 			Example
 				CI=true npx gocd-cypress --cypressCmd="cypress run" \\
-					--serveCmd="npm start" --serveHost=http://localhost:3000 \\
+					--serveCmd="npm start" --serveHost=http://localhost:4200 \\
 					--resultsFolder="build/cypress/results" --reportsFolder="build/cypress/reports"
 			`,
 			builder: (args: Argv<ArgTypes>) => {

--- a/src/dockerize.ts
+++ b/src/dockerize.ts
@@ -25,8 +25,8 @@ export function dockerize(realHandler: YargsHandler): YargsHandler {
 
 			console.log(chalk.inverse(`Command: ${command}`));
 
-			const { stdout: userId } = await exec('id -u', {stdout: 'pipe'});
-			const { stdout: groupId } = await exec('id -g', {stdout: 'pipe'});
+			const { stdout: userId } = await exec('id -u', { stdout: 'pipe' });
+			const { stdout: groupId } = await exec('id -g', { stdout: 'pipe' });
 			const HOME = process.env.HOME;
 			const cypressEnvVars = findCypressEnvVars().map(envVarDef => ['-e', envVarDef]).flat();
 

--- a/src/dockerize.ts
+++ b/src/dockerize.ts
@@ -19,7 +19,9 @@ export function dockerize(realHandler: YargsHandler): YargsHandler {
 
 			const command = [
 				'npx gocd-cypress',
-				...hideBin(process.argv).filter(arg => !arg.startsWith('--docker')),
+				...hideBin(process.argv).filter(arg => !arg.startsWith('--docker'))
+					.map(arg => arg.replace(/"/g, '\\"'))
+					.map(arg => `"${arg}"`),
 				'--docker=false',
 			].join(' ');
 

--- a/src/dockerize.ts
+++ b/src/dockerize.ts
@@ -28,25 +28,22 @@ export function dockerize(realHandler: YargsHandler): YargsHandler {
 			const { stdout: userId } = await exec('id -u', {stdout: 'pipe'});
 			const { stdout: groupId } = await exec('id -g', {stdout: 'pipe'});
 			const HOME = process.env.HOME;
-			const containerName = `cypress-runner-${projectName()}`;
 			const cypressEnvVars = findCypressEnvVars().map(envVarDef => ['-e', envVarDef]).flat();
 
 			console.log(chalk.inverse(`Bootstrap command: ${CY_BOOTSTRAP_COMMAND}`));
 
 			await execa(`docker`, ['run',
-				'--name', containerName,
+				'--name', `cypress-runner-${projectName()}`,
 				'--rm',
 				'--init',
 				'--user', `${userId}:${groupId}`,
 				...(!isCI ? ['-t'] : []),
 				'-v', `${HOME}:/opt/cypress/home`,
-				'-v', `${HOME}/.cache/Cypress:/opt/cypress/cache`,
-				'-v', `${CY_PROJECT_PATH}:/e2e`,
-				'-w', '/e2e',
+				'-v', `${CY_PROJECT_PATH}:/workdir`,
+				'-w', '/workdir',
 				'-e', 'HOME=/opt/cypress/home',
-				'-e', 'NPM_CONFIG_PREFIX=/e2e',
+				'-e', 'NPM_CONFIG_PREFIX=/workdir',
 				...cypressEnvVars,
-				'-e', 'CYPRESS_CACHE_FOLDER=/opt/cypress/cache',
 				'-e', 'HTTP_PROXY', '-e', 'HTTPS_PROXY', '-e', 'NO_PROXY',
 				'-e', 'http_proxy', '-e', 'https_proxy', '-e', 'no_proxy',
 				...(isCI ? ['-e', 'CI'] : []),

--- a/test/reports.spec.ts
+++ b/test/reports.spec.ts
@@ -35,8 +35,16 @@ describe('cli', function () {
 
 	it('generates reports with dev web server and with docker', async () => {
 		await runCypress(WITH_DOCKER, [
-			'--serveCmd="npm start"',
+			'--serveCmd=npm start',
 			'--serveHost=http://localhost:4200']
+		);
+		expectHtmlReportExists();
+	});
+
+	it('escapes quotes', async () => {
+		await runCypress(WITH_DOCKER, [
+			'--serveCmd=`echo "npm" \'run\' "start"`',
+			'--serveHost="http://localhost:4200"']
 		);
 		expectHtmlReportExists();
 	});
@@ -78,7 +86,7 @@ describe('cli', function () {
 
 		const { all } = await execa('gocd-cypress', [
 			`--docker=${dockerEnabled}`,
-			`--cypressCmd="cypress run --browser ${browser}"`,
+			`--cypressCmd=cypress run --browser ${browser}`,
 			...cypressArgs
 		], {
 			preferLocal: true,

--- a/test/reports.spec.ts
+++ b/test/reports.spec.ts
@@ -53,6 +53,11 @@ describe('cli', function () {
 					res.writeHead(200);
 					res.end(html);
 				})
+				.on('error', function (e) {
+					console.error(e);
+					reject(e);
+					server.close();
+				})
 				.listen(port, host, async () => {
 					try {
 						await callback();
@@ -73,7 +78,7 @@ describe('cli', function () {
 
 		const { all } = await execa('gocd-cypress', [
 			`--docker=${dockerEnabled}`,
-			`--cypressCmd="npx cypress run --browser ${browser}"`,
+			`--cypressCmd="cypress run --browser ${browser}"`,
 			...cypressArgs
 		], {
 			preferLocal: true,


### PR DESCRIPTION
* `CYPRESS_CACHE_FOLDER` already defaults to `~/.cache/Cypress`, so no need to set it to a different folder in the container.
* `/e2e` is a misleading work directory path because Cypress can also do component testing or UI integration/acceptance testing.
* Removed some git ignores for paths I cannot reproduce anymore (it was probably my mistake).