### PR TITLE
Use Cosmiconfig for configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,42 +39,74 @@ npx gocd-cypress --help
 
 # Configuration
 
-Configuration keys can be defined
- - in `package.json` in `gocdCypress` property:
-   ```json
-   {
-       "name": "my-project",
-       "version": "0.0.0",
-       "gocdCypress": {
-           "CY_DOCKER_IMAGE": "cypress/browsers:node16.13.0-chrome95-ff94"
-       }
-   }
-   ```
- - via environment variable:
-   ```bash
-   export CY_DOCKER_IMAGE=cypress/browsers:node16.13.0-chrome95-ff94
-   npx gocd-cypress
-   ```
+This tool uses [Cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for the configuration options, see its 
+documentation about where you can define your options. The module name we use with it is `gocdCypress`.
+
+Example in `package.json`:
+```json
+{
+    "name": "my-project",
+    "version": "0.0.0",
+    "gocdCypress": {
+        "cypressCmd": "cypress run --browser firefox",
+        "dockerImage": "cypress/browsers:node16.13.0-chrome95-ff94"
+    }
+}
+```
+
+We also support profiles that override non-profile-specific or default values, and they can be selected with command-line 
+option `--profile`:
+
+```json
+{
+    "gocdCypress": {
+        "cypressCmd": "cypress run --browser electron",
+        "profiles": {
+             "browserChrome": {
+                "cypressCmd": "cypress run --browser chrome"
+             },
+             "browserFirefox": {
+                "cypressCmd": "cypress run --browser firefox"
+             }
+        }
+    }
+}
+```
+
+Environment variables can override Cosmiconfig options. Each option is mapped to an environment variable with its name 
+converted to underscore case and prefixed with `CY_`. For example:
+
+```bash
+export CY_DOCKER_IMAGE=cypress/browsers:node16.13.0-chrome95-ff94
+export CY_CYPRESS_CMD='cypress run --browser firefox'
+npx gocd-cypress
+```
+
+Command-line options have the highest precedence over other means of configuration.
 
 ## Configuration keys
 
-### CY_PROJECT_PATH
+### Command-line options
+
+All command-line options are also available as Cosmiconfig options.
+
+### `projectPath`
 
 *default:* `process.cwd()`
 
-root path of project
+Root path of project.
 
-### CY_DOCKER_IMAGE
+### `dockerImage`
 
 *default:* `'cypress/browsers:node16.13.0-chrome95-ff94'`
 
-Docker image name that is used when testing is running in container mode.
+Docker image name and tag that is used when testing is run in container mode.
 
-### CY_BOOTSTRAP_COMMAND
+### `bootstrapCommand`
 
 *default:* `'true'`
 
-Optional command that is invoked in container mode, before testing
+Optional command that is invoked in container mode, before testing.
 
 ## CI/CD integration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "gocd-cypress",
-	"version": "1.1.2",
+	"version": "2.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gocd-cypress",
-			"version": "1.1.2",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",
+				"cosmiconfig": "^7.0.1",
 				"execa": "^5.1.1",
 				"mochawesome": "^7.1.3",
 				"mochawesome-merge": "^4.2.1",
@@ -53,7 +54,6 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
 			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/highlight": "^7.16.7"
 			},
@@ -266,7 +266,6 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
 			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -298,7 +297,6 @@
 			"version": "7.17.12",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
 			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
@@ -312,7 +310,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -324,7 +321,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -338,7 +334,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -346,14 +341,12 @@
 		"node_modules/@babel/highlight/node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 		},
 		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -362,7 +355,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -371,7 +363,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -1422,6 +1413,11 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.15.tgz",
 			"integrity": "sha512-zWt4SDDv1S9WRBNxLFxFRHxdD9tvH8f5/kg5/IaLFdnSNXsDY4eL3Q3XXN+VxUnWIhyVFDwcsmAprvwXoM/ClA=="
 		},
+		"node_modules/@types/parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+		},
 		"node_modules/@types/prettier": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
@@ -2179,7 +2175,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2452,6 +2447,21 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
 			"peer": true
+		},
+		"node_modules/cosmiconfig": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+			"dependencies": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/create-require": {
 			"version": "1.1.1",
@@ -2784,7 +2794,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -3642,7 +3651,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-			"dev": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -3717,8 +3725,7 @@
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"dev": true
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -4553,8 +4560,7 @@
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
 		},
 		"node_modules/json-schema": {
 			"version": "0.4.0",
@@ -4660,8 +4666,7 @@
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
 		},
 		"node_modules/listr2": {
 			"version": "3.14.0",
@@ -5466,7 +5471,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -5478,7 +5482,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
 				"error-ex": "^1.3.1",
@@ -5526,7 +5529,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -5828,7 +5830,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -6652,6 +6653,14 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
+		"node_modules/yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/yargs": {
 			"version": "17.3.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
@@ -6762,7 +6771,6 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
 			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.16.7"
 			}
@@ -6925,8 +6933,7 @@
 		"@babel/helper-validator-identifier": {
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-			"dev": true
+			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
 		},
 		"@babel/helper-validator-option": {
 			"version": "7.16.7",
@@ -6949,7 +6956,6 @@
 			"version": "7.17.12",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
 			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
@@ -6960,7 +6966,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -6969,7 +6974,6 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -6980,7 +6984,6 @@
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
 					"requires": {
 						"color-name": "1.1.3"
 					}
@@ -6988,26 +6991,22 @@
 				"color-name": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-					"dev": true
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-					"dev": true
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-					"dev": true
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -7873,6 +7872,11 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.15.tgz",
 			"integrity": "sha512-zWt4SDDv1S9WRBNxLFxFRHxdD9tvH8f5/kg5/IaLFdnSNXsDY4eL3Q3XXN+VxUnWIhyVFDwcsmAprvwXoM/ClA=="
 		},
+		"@types/parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+		},
 		"@types/prettier": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
@@ -8388,8 +8392,7 @@
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
 		},
 		"camelcase": {
 			"version": "5.3.1",
@@ -8591,6 +8594,18 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
 			"peer": true
+		},
+		"cosmiconfig": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+			"requires": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			}
 		},
 		"create-require": {
 			"version": "1.1.1",
@@ -8847,7 +8862,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -9479,7 +9493,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-			"dev": true,
 			"requires": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -9530,8 +9543,7 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"dev": true
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
@@ -10164,8 +10176,7 @@
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
 		},
 		"json-schema": {
 			"version": "0.4.0",
@@ -10248,8 +10259,7 @@
 		"lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
 		},
 		"listr2": {
 			"version": "3.14.0",
@@ -10864,7 +10874,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
 			}
@@ -10873,7 +10882,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
 			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"error-ex": "^1.3.1",
@@ -10905,8 +10913,7 @@
 		"path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 		},
 		"pend": {
 			"version": "1.2.0",
@@ -11128,8 +11135,7 @@
 		"resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 		},
 		"resolve.exports": {
 			"version": "1.1.0",
@@ -11706,6 +11712,11 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		},
+		"yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
 		},
 		"yargs": {
 			"version": "17.3.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"chalk": "^4.1.2",
+		"cosmiconfig": "^7.0.1",
 		"execa": "^5.1.1",
 		"mochawesome": "^7.1.3",
 		"mochawesome-merge": "^4.2.1",

--- a/project-under-test/package.json
+++ b/project-under-test/package.json
@@ -12,5 +12,13 @@
   "keywords": [],
   "devDependencies": {
     "cypress": "^9.4.1"
+  },
+  "gocdCypress": {
+    "CY_DOCKER_IMAGE": "cypress/browsers:node16.13.0-chrome95-ff94",
+    "profiles": {
+      "testBootstrap": {
+        "bootstrapCommand": "echo 'This is a dummy bootstrap command'"
+      }
+    }
   }
 }

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -12,6 +12,7 @@ export type ArgTypes = {
 	serveHost?: string;
 	resultsFolder?: string;
 	reportsFolder?: string;
+	profile?: string;
 };
 
 // Assemble CLI interface with yargs
@@ -24,7 +25,7 @@ export function buildCli(): Argv {
 			describe: `Starts Cypress testing
 
 			Example
-				CI=true npx gocd-cypress --cypressCmd="cypress run" \\
+				CI=true npx gocd-cypress --cypressCmd="cypress run --browser chrome" \\
 					--serveCmd="npm start" --serveHost=http://localhost:4200 \\
 					--resultsFolder="build/cypress/results" --reportsFolder="build/cypress/reports"
 			`,
@@ -60,12 +61,15 @@ export function buildCli(): Argv {
 							type: 'string',
 							default: DEFAULT_REPORTS_FOLDER,
 						},
+						profile: {
+							describe: 'Configuration profile to use. Overrides configuration based on use case',
+							type: 'string',
+						}
 					})
 					.implies('serveCmd', 'serveHost');
 			},
 			handler: runHandler,
 		})
-		.showHelpOnFail(false)
-		.demandCommand(1);
+		.showHelpOnFail(false);
 
 }

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -1,20 +1,5 @@
 import execa from 'execa';
-import path from 'path';
-
-const PROJECT_PACKAGE_JSON_PROPERTY = 'gocdCypress';
-
-const packageJson = () => require(path.resolve(process.cwd(), 'package.json'));
-
-export const gocdCypressConfig = (): Record<string, string> => packageJson()[PROJECT_PACKAGE_JSON_PROPERTY] ?? {};
-export const projectName = (): string => packageJson().name;
-
-function config(envVarName: string, defaultValue: string): string {
-	return process.env[envVarName] || gocdCypressConfig()[envVarName] || defaultValue;
-}
-
-export const CY_PROJECT_PATH = config('CY_PROJECT_PATH', process.cwd());
-export const CY_DOCKER_IMAGE = config('CY_DOCKER_IMAGE', 'cypress/browsers:node16.13.0-chrome95-ff94');
-export const CY_BOOTSTRAP_COMMAND = config('CY_BOOTSTRAP_COMMAND', 'true');
+import { config } from './config';
 
 export function exec(command: string, options?: execa.Options): execa.ExecaChildProcess {
 
@@ -23,7 +8,7 @@ export function exec(command: string, options?: execa.Options): execa.ExecaChild
 		stdin: 'ignore',
 		stdout: 'inherit',
 		stderr: 'inherit',
-		cwd: CY_PROJECT_PATH,
+		cwd: config.projectPath,
 		...options,
 	});
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,64 @@
+import path from 'path';
+import { cosmiconfigSync } from 'cosmiconfig';
+import { Arguments } from 'yargs';
+import { ArgTypes } from './cli-builder';
+
+export type Config = Arguments<ArgTypes> & {
+	projectPath: string,
+	dockerImage: string,
+	bootstrapCommand: string,
+};
+
+const defaultConfig: Partial<Config> = {
+	projectPath: process.cwd(),
+	dockerImage: 'cypress/browsers:node16.13.0-chrome95-ff94',
+	bootstrapCommand: 'true'
+};
+
+export let config: Config;
+
+export const loadConfig = (argv: Arguments<ArgTypes>): void => {
+	const cosmiconfig = loadCosmiconfig() ?? {};
+
+	const nonProfileConfig = Object.fromEntries(Object.entries({ ...cosmiconfig }).filter(([k]) => k !== 'profiles'));
+	const profileConfig = (argv.profile ? (cosmiconfig.profiles?.[argv.profile] ?? {}) : {});
+	const commandLineConfig = Object.fromEntries(Object.entries(argv).filter(([k]) => k !== 'profile'));
+
+	config = {
+		...defaultConfig,
+		...nonProfileConfig,
+		...profileConfig,
+		...convertCyEnvVarsToConfigProps(process.env),
+		...commandLineConfig
+	};
+};
+
+const loadCosmiconfig = () => {
+	const COSMICONFIG_MODULE_NAME = 'gocdCypress';
+
+	try {
+		return cosmiconfigSync(COSMICONFIG_MODULE_NAME).search()?.config || {};
+	}
+	catch (error) {
+		throw new Error(`Unable to load ${COSMICONFIG_MODULE_NAME} configuration: ${error}`);
+	}
+};
+
+export const convertCyEnvVarsToConfigProps = (envVars: Record<string, string | undefined>): Record<string, string | undefined> =>
+	Object.fromEntries(
+		Object.entries(envVars)
+			.filter(([k]) => k.startsWith('CY_'))
+			.map(([k, v]) => [convertUnderscoreCaseToSnakeCase(k.replace(/^CY_/, '')), v]));
+
+export const convertUnderscoreCaseToSnakeCase = (str: string) => {
+	const words = str.split('_');
+	return [
+		...words.slice(0, 1).map(word => word.toLowerCase()),
+		...words.slice(1).map(word =>
+			word.slice(0, 1).toUpperCase() + word.slice(1).toLowerCase())
+	].join('');
+}
+
+export const loadProjectName = (): string =>
+	//eslint-disable-next-line @typescript-eslint/no-var-requires
+	require(path.resolve(process.cwd(), 'package.json')).name;

--- a/src/dockerize.ts
+++ b/src/dockerize.ts
@@ -4,71 +4,61 @@ import { exec, findCypressEnvVars, isCI } from './commons';
 import { hideBin } from 'yargs/helpers';
 import { config, loadProjectName } from './config';
 
-export function dockerize(realHandler: () => Promise<void>): () => Promise<void> {
+export const dockerize: () => void = async () => {
 
-	return async () => {
+	console.log(chalk.inverse(`🐳 Docker mode: using ${config.dockerImage}`));
 
-		if (config.docker) {
+	const command = [
+		'npx gocd-cypress',
+		...hideBin(process.argv).filter(arg => !arg.startsWith('--docker'))
+			.map(arg => arg.replace(/"/g, '\\"'))
+			.map(arg => `"${arg}"`),
+		'--docker=false',
+	].join(' ');
 
-			console.log(chalk.inverse(`🐳 Docker mode: using ${config.dockerImage}`));
+	console.log(chalk.inverse(`Command: ${command}`));
 
-			const command = [
-				'npx gocd-cypress',
-				...hideBin(process.argv).filter(arg => !arg.startsWith('--docker'))
-					.map(arg => arg.replace(/"/g, '\\"'))
-					.map(arg => `"${arg}"`),
-				'--docker=false',
-			].join(' ');
+	const { stdout: userId } = await exec('id -u', { stdout: 'pipe' });
+	const { stdout: groupId } = await exec('id -g', { stdout: 'pipe' });
+	const HOME = process.env.HOME;
+	const cypressEnvVars = findCypressEnvVars().map(envVarDef => ['-e', envVarDef]).flat();
 
-			console.log(chalk.inverse(`Command: ${command}`));
+	console.log(chalk.inverse(`Bootstrap command: ${config.bootstrapCommand}`));
 
-			const { stdout: userId } = await exec('id -u', { stdout: 'pipe' });
-			const { stdout: groupId } = await exec('id -g', { stdout: 'pipe' });
-			const HOME = process.env.HOME;
-			const cypressEnvVars = findCypressEnvVars().map(envVarDef => ['-e', envVarDef]).flat();
+	await execa(`docker`, ['run',
+		'--name', `cypress-runner-${loadProjectName()}`,
+		'--rm',
+		'--init',
+		'--user', `${userId}:${groupId}`,
+		...(!isCI ? ['-t'] : []),
+		'-v', `${HOME}:/opt/cypress/home`,
+		'-v', `${config.projectPath}:/workdir`,
+		'-w', '/workdir',
+		'-e', 'HOME=/opt/cypress/home',
+		'-e', 'NPM_CONFIG_PREFIX=/workdir',
+		...cypressEnvVars,
+		'-e', 'HTTP_PROXY', '-e', 'HTTPS_PROXY', '-e', 'NO_PROXY',
+		'-e', 'http_proxy', '-e', 'https_proxy', '-e', 'no_proxy',
+		...(isCI ? ['-e', 'CI'] : []),
+		'--entrypoint=bash',
+		config.dockerImage,
+		'-c', // bash command execution flag
+		[
+			// bootstrap project if it was defined
+			config.bootstrapCommand,
 
-			console.log(chalk.inverse(`Bootstrap command: ${config.bootstrapCommand}`));
+			// install cypress binary
+			`npx cypress install`,
 
-			await execa(`docker`, ['run',
-				'--name', `cypress-runner-${loadProjectName()}`,
-				'--rm',
-				'--init',
-				'--user', `${userId}:${groupId}`,
-				...(!isCI ? ['-t'] : []),
-				'-v', `${HOME}:/opt/cypress/home`,
-				'-v', `${config.projectPath}:/workdir`,
-				'-w', '/workdir',
-				'-e', 'HOME=/opt/cypress/home',
-				'-e', 'NPM_CONFIG_PREFIX=/workdir',
-				...cypressEnvVars,
-				'-e', 'HTTP_PROXY', '-e', 'HTTPS_PROXY', '-e', 'NO_PROXY',
-				'-e', 'http_proxy', '-e', 'https_proxy', '-e', 'no_proxy',
-				...(isCI ? ['-e', 'CI'] : []),
-				'--entrypoint=bash',
-				config.dockerImage,
-				'-c', // bash command execution flag
-				[
-					// bootstrap project if it was defined
-					config.bootstrapCommand,
+			// finally run command as tester user
+			command,
 
-					// install cypress binary
-					`npx cypress install`,
+		].join(' && '), // join bash commands
+	], {
+		cwd: config.projectPath,
+		stdin: 'ignore',
+		stdout: 'inherit',
+		stderr: 'inherit',
+	});
 
-					// finally run command as tester user
-					command,
-
-				].join(' && '), // join bash commands
-			], {
-				cwd: config.projectPath,
-				stdin: 'ignore',
-				stdout: 'inherit',
-				stderr: 'inherit',
-			});
-
-		}
-		else {
-			await realHandler();
-		}
-
-	};
-}
+};

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -6,7 +6,18 @@ import { config, loadConfig } from './config';
 import { ArgTypes } from './cli-builder';
 import { Arguments } from 'yargs';
 
-async function runCommand() {
+export const runHandler = (argv: Arguments<ArgTypes>) => {
+	loadConfig(argv);
+
+	if (config.docker) {
+		dockerize();
+	}
+	else {
+		runCommand();
+	}
+}
+
+export const runCommand: () => void = async () => {
 	if (config.serveCmd) {
 		await runWithStartCommand(
 			config.serveCmd,
@@ -83,8 +94,3 @@ const runWithStartCommand = async (serveCmd: string, serveHost: string, runCypre
 		process.exit(exitCode);
 	}
 };
-
-export const runHandler = (argv: Arguments<ArgTypes>) => {
-	loadConfig(argv);
-	dockerize(runCommand)();
-}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,30 +1,30 @@
-import { Arguments } from 'yargs';
 import waitOn from 'wait-on';
-import { ArgTypes } from './cli-builder';
-import { cleanUpFolder, CY_PROJECT_PATH, exec, } from './commons';
+import { cleanUpFolder, exec, } from './commons';
 import { dockerize } from './dockerize';
 import path from 'path';
+import { config, loadConfig } from './config';
+import { ArgTypes } from './cli-builder';
+import { Arguments } from 'yargs';
 
-async function runCommand(argv: Arguments<ArgTypes>) {
-
-	if (argv.serveCmd) {
+async function runCommand() {
+	if (config.serveCmd) {
 		await runWithStartCommand(
-			argv.serveCmd,
-			argv.serveHost as string,
+			config.serveCmd,
+			config.serveHost as string,
 			async () => {
 				await runCypress(
-					argv.cypressCmd as string,
-					argv.resultsFolder as string,
-					argv.reportsFolder as string,
+					config.cypressCmd as string,
+					config.resultsFolder as string,
+					config.reportsFolder as string,
 				);
 			},
 		);
 	}
 	else {
 		await runCypress(
-			argv.cypressCmd as string,
-			argv.resultsFolder as string,
-			argv.reportsFolder as string,
+			config.cypressCmd as string,
+			config.resultsFolder as string,
+			config.reportsFolder as string,
 		);
 	}
 
@@ -32,8 +32,8 @@ async function runCommand(argv: Arguments<ArgTypes>) {
 
 async function runCypress(cypressCmd: string, resultsFolder: string, reportsFolder: string) {
 
-	const resultsFolderAbs = path.resolve(CY_PROJECT_PATH, resultsFolder);
-	const reportsFolderAbs = path.resolve(CY_PROJECT_PATH, reportsFolder);
+	const resultsFolderAbs = path.resolve(config.projectPath, resultsFolder);
+	const reportsFolderAbs = path.resolve(config.projectPath, reportsFolder);
 
 	try {
 		await cleanUpFolder(resultsFolderAbs);
@@ -84,4 +84,7 @@ const runWithStartCommand = async (serveCmd: string, serveHost: string, runCypre
 	}
 };
 
-export const runHandler = dockerize(runCommand);
+export const runHandler = (argv: Arguments<ArgTypes>) => {
+	loadConfig(argv);
+	dockerize(runCommand)();
+}

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -36,17 +36,26 @@ describe('cli', function () {
 	it('generates reports with dev web server and with docker', async () => {
 		await runCypress(WITH_DOCKER, [
 			'--serveCmd=npm start',
-			'--serveHost=http://localhost:4200']
-		);
+			'--serveHost=http://localhost:4200',
+		]);
 		expectHtmlReportExists();
 	});
 
 	it('escapes quotes', async () => {
 		await runCypress(WITH_DOCKER, [
 			'--serveCmd=`echo "npm" \'run\' "start"`',
-			'--serveHost="http://localhost:4200"']
-		);
+			'--serveHost="http://localhost:4200"',
+		]);
 		expectHtmlReportExists();
+	});
+
+	it('can use a different profile', async () => {
+		const all = await runCypress(WITH_DOCKER, [
+			'--serveCmd=`echo "npm" \'run\' "start"`',
+			'--serveHost="http://localhost:4200"',
+			'--profile=testBootstrap',
+		]);
+		expect(all).toContain('This is a dummy bootstrap command');
 	});
 
 	const withMockDevWebServer = (callback: () => Promise<void>) => {
@@ -81,7 +90,7 @@ describe('cli', function () {
 		});
 	};
 
-	const runCypress = async (dockerEnabled: boolean, cypressArgs: string[] = []) => {
+	const runCypress = async (dockerEnabled: boolean, cypressArgs: string[] = []): Promise<string> => {
 		const browser = dockerEnabled ? 'chrome' : 'electron';
 
 		const { all } = await execa('gocd-cypress', [
@@ -94,6 +103,8 @@ describe('cli', function () {
 			stdin: 'ignore'
 		});
 		console.log(all);
+
+		return all ?? '';
 	}
 
 	const expectHtmlReportExists = () => {

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -1,0 +1,11 @@
+import { convertCyEnvVarsToConfigProps, convertUnderscoreCaseToSnakeCase } from '../src/config';
+
+describe('config', function () {
+	it('converts underscore case to snake case', () => {
+		expect(convertUnderscoreCaseToSnakeCase('MY_TEST_VARIABLE')).toEqual('myTestVariable');
+	});
+
+	it('converts converts env vars to config props', () => {
+		expect(convertCyEnvVarsToConfigProps({ 'CY_TEST_VARIABLE': 'my value' })).toEqual({ testVariable: 'my value' });
+	});
+});


### PR DESCRIPTION
- Now all command-line options can be specified as configuration options in `package.json` or in other places that Cosmiconfig
  supports. In addition, configuration profiles can be defined that override such options. These features will help alleviate
  the problem of too long lines of NPM scripts using `gocd-cypress` in `package.json`.
- Some underscore-case configuration keys have been normalized to snake-case keys. (Breaks compatibility.)