### PR TITLE
Fix Yargs defaults overriding Cosmiconfig options

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Root path of project.
 
 Docker image name and tag that is used when testing is run in container mode.
 
-### `bootstrapCommand`
+### `bootstrapCmd`
 
 *default:* `'true'`
 

--- a/project-under-test/package.json
+++ b/project-under-test/package.json
@@ -17,7 +17,7 @@
     "CY_DOCKER_IMAGE": "cypress/browsers:node16.13.0-chrome95-ff94",
     "profiles": {
       "testBootstrap": {
-        "bootstrapCommand": "echo 'This is a dummy bootstrap command'"
+        "bootstrapCmd": "echo 'This is a dummy bootstrap command'"
       }
     }
   }

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -1,13 +1,11 @@
 import yargs, { Argv } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { runHandler } from './runner';
-import { isCI } from './commons';
-
-export const DEFAULT_REPORTS_FOLDER = 'cypress/results';
+import { defaultConfig } from './config';
 
 export type ArgTypes = {
 	docker?: boolean;
-	cypressCommand?: string;
+	cypressCmd?: string;
 	serveCmd?: string;
 	serveHost?: string;
 	resultsFolder?: string;
@@ -16,9 +14,8 @@ export type ArgTypes = {
 };
 
 // Assemble CLI interface with yargs
-export function buildCli(): Argv {
-
-	return yargs(hideBin(process.argv))
+export const buildCli = (): Argv =>
+	yargs(hideBin(process.argv))
 		.help()
 		.command({
 			command: '$0',
@@ -33,15 +30,15 @@ export function buildCli(): Argv {
 				return args
 					.options({
 						docker: {
-							describe: 'Run Cypress in Docker. Defaults to true if a CI environment is detected',
-							default: isCI,
+							describe: withDefault('Run Cypress in Docker. Defaults to true if a CI environment is detected',
+								defaultConfig.docker as boolean),
 							boolean: true,
 						},
 						cypressCmd: {
-							describe: 'Command to execute Cypress tests. Must support receiving more parameters that customize' +
-								' the reporter',
+							describe: withDefault('Command to execute Cypress tests. Must support receiving more parameters' +
+								' that customize the reporter',
+								defaultConfig.cypressCmd as string),
 							type: 'string',
-							default: 'cypress run'
 						},
 						serveCmd: {
 							describe: 'Serve command',
@@ -52,14 +49,14 @@ export function buildCli(): Argv {
 							type: 'string',
 						},
 						resultsFolder: {
-							describe: 'Path to the folder to store intermediary test result files in',
+							describe: withDefault('Path to the folder to store intermediary test result files in',
+								defaultConfig.resultsFolder as string),
 							type: 'string',
-							default: DEFAULT_REPORTS_FOLDER,
 						},
 						reportsFolder: {
-							describe: 'Path to the folder to create the HTML report in',
+							describe: withDefault('Path to the folder to create the HTML report in',
+								defaultConfig.reportsFolder as string),
 							type: 'string',
-							default: DEFAULT_REPORTS_FOLDER,
 						},
 						profile: {
 							describe: 'Configuration profile to use. Overrides configuration based on use case',
@@ -72,4 +69,6 @@ export function buildCli(): Argv {
 		})
 		.showHelpOnFail(false);
 
-}
+// Can't define default values with yargs, as in our setup they would always override the Cosmiconfig configuration too.
+const withDefault = (description: string, defaultValue: string | boolean) =>
+	`${description} [default: ${defaultValue}]`;

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -1,17 +1,17 @@
 import execa from 'execa';
-import { config } from './config';
 
-export function exec(command: string, options?: execa.Options): execa.ExecaChildProcess {
+export const DEFAULT_PROJECT_PATH = process.cwd();
+export const IS_CI = ['1', 'true'].includes('' + process.env.CI);
 
-	return execa.command(command, {
+export const exec = (command: string, options?: execa.Options): execa.ExecaChildProcess =>
+	execa.command(command, {
 		preferLocal: true,
 		stdin: 'ignore',
 		stdout: 'inherit',
 		stderr: 'inherit',
-		cwd: config.projectPath,
+		cwd: DEFAULT_PROJECT_PATH,
 		...options,
 	});
-}
 
 export const cleanUpFolder = async (folder: string): Promise<void> => {
 	await exec(`rm -rf ${folder}`);
@@ -21,5 +21,3 @@ export const findCypressEnvVars = (): string[] =>
 	Object.keys(process.env)
 		.filter(envVar => envVar.toUpperCase().startsWith('CYPRESS_'))
 		.map(envVar => `${envVar}=${process.env[envVar]}`);
-
-export const isCI = ['1', 'true'].includes('' + process.env.CI);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { cosmiconfigSync } from 'cosmiconfig';
 import { Arguments } from 'yargs';
 import { ArgTypes } from './cli-builder';
-import { isCI } from './commons';
+import { DEFAULT_PROJECT_PATH, IS_CI } from './commons';
 
 export type Config = Arguments<ArgTypes> & {
 	projectPath: string,
@@ -11,10 +11,10 @@ export type Config = Arguments<ArgTypes> & {
 };
 
 export const defaultConfig: Partial<Config> = {
-	projectPath: process.cwd(),
+	projectPath: DEFAULT_PROJECT_PATH,
 	dockerImage: 'cypress/browsers:node16.13.0-chrome95-ff94',
 	bootstrapCmd: 'true',
-	docker: isCI,
+	docker: IS_CI,
 	cypressCmd: 'cypress run',
 	resultsFolder: 'cypress/results',
 	reportsFolder: 'cypress/reports',

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,17 +2,22 @@ import path from 'path';
 import { cosmiconfigSync } from 'cosmiconfig';
 import { Arguments } from 'yargs';
 import { ArgTypes } from './cli-builder';
+import { isCI } from './commons';
 
 export type Config = Arguments<ArgTypes> & {
 	projectPath: string,
 	dockerImage: string,
-	bootstrapCommand: string,
+	bootstrapCmd: string,
 };
 
-const defaultConfig: Partial<Config> = {
+export const defaultConfig: Partial<Config> = {
 	projectPath: process.cwd(),
 	dockerImage: 'cypress/browsers:node16.13.0-chrome95-ff94',
-	bootstrapCommand: 'true'
+	bootstrapCmd: 'true',
+	docker: isCI,
+	cypressCmd: 'cypress run',
+	resultsFolder: 'cypress/results',
+	reportsFolder: 'cypress/reports',
 };
 
 export let config: Config;

--- a/src/dockerize.ts
+++ b/src/dockerize.ts
@@ -23,7 +23,7 @@ export const dockerize: () => void = async () => {
 	const HOME = process.env.HOME;
 	const cypressEnvVars = findCypressEnvVars().map(envVarDef => ['-e', envVarDef]).flat();
 
-	console.log(chalk.inverse(`Bootstrap command: ${config.bootstrapCommand}`));
+	console.log(chalk.inverse(`Bootstrap command: ${config.bootstrapCmd}`));
 
 	await execa(`docker`, ['run',
 		'--name', `cypress-runner-${loadProjectName()}`,
@@ -45,7 +45,7 @@ export const dockerize: () => void = async () => {
 		'-c', // bash command execution flag
 		[
 			// bootstrap project if it was defined
-			config.bootstrapCommand,
+			config.bootstrapCmd,
 
 			// install cypress binary
 			`npx cypress install`,

--- a/src/dockerize.ts
+++ b/src/dockerize.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import execa from 'execa';
-import { exec, findCypressEnvVars, isCI } from './commons';
+import { exec, findCypressEnvVars, IS_CI } from './commons';
 import { hideBin } from 'yargs/helpers';
 import { config, loadProjectName } from './config';
 
@@ -30,7 +30,7 @@ export const dockerize: () => void = async () => {
 		'--rm',
 		'--init',
 		'--user', `${userId}:${groupId}`,
-		...(!isCI ? ['-t'] : []),
+		...(!IS_CI ? ['-t'] : []),
 		'-v', `${HOME}:/opt/cypress/home`,
 		'-v', `${config.projectPath}:/workdir`,
 		'-w', '/workdir',
@@ -39,7 +39,7 @@ export const dockerize: () => void = async () => {
 		...cypressEnvVars,
 		'-e', 'HTTP_PROXY', '-e', 'HTTPS_PROXY', '-e', 'NO_PROXY',
 		'-e', 'http_proxy', '-e', 'https_proxy', '-e', 'no_proxy',
-		...(isCI ? ['-e', 'CI'] : []),
+		...(IS_CI ? ['-e', 'CI'] : []),
 		'--entrypoint=bash',
 		config.dockerImage,
 		'-c', // bash command execution flag

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -5,7 +5,13 @@ describe('config', function () {
 		expect(convertUnderscoreCaseToSnakeCase('MY_TEST_VARIABLE')).toEqual('myTestVariable');
 	});
 
-	it('converts converts env vars to config props', () => {
-		expect(convertCyEnvVarsToConfigProps({ 'CY_TEST_VARIABLE': 'my value' })).toEqual({ testVariable: 'my value' });
+	it('converts CY_ env vars to config props', () => {
+		expect(convertCyEnvVarsToConfigProps({
+			'CY_TEST_VARIABLE': 'my value',
+			HOME: 'this variable should not be converted',
+			CYPRESS_CMD: 'testing a wrongly named env var'
+		})).toEqual({
+			testVariable: 'my value'
+		});
 	});
 });


### PR DESCRIPTION
Also renamed `bootstrapCommand` to `bootstrapCmd` to follow existing command-line option naming convention.