### PR TITLE
Propagate exit codes when using Node.js <16

### DIFF
--- a/src/dockerize.ts
+++ b/src/dockerize.ts
@@ -4,7 +4,7 @@ import { exec, findCypressEnvVars, IS_CI } from './commons';
 import { hideBin } from 'yargs/helpers';
 import { config, loadProjectName } from './config';
 
-export const dockerize: () => void = async () => {
+export const dockerize = async (): Promise<void> => {
 
 	console.log(chalk.inverse(`🐳 Docker mode: using ${config.dockerImage}`));
 


### PR DESCRIPTION
Exit code propagation only happened so far during running cypress with a serve command. This has been a problem with Node.js versions earlier than 16 (like 12 or 14, although only version 14 is officially supported today).

The newly added tests never fail with Node.js 16, I executed them with Node.js 14 to reproduce the bug.